### PR TITLE
Update abstract_converter.py to make CLI work

### DIFF
--- a/src/sdrf_convert/abstract_converter.py
+++ b/src/sdrf_convert/abstract_converter.py
@@ -217,7 +217,7 @@ class AbstractConverter:
         raise NotImplementedError(f"Method convert() not implemented for {cls.__name__}")
     
     @classmethod
-    def convert_via_cli(cli_args: argparse.Namespace):
+    def convert_via_cli(cls, cli_args: argparse.Namespace):
         """Uses the CLI arguments convert a SDRF file to the tool config.
         Example for an implemented subclass:
         ```python


### PR DESCRIPTION
The cls must be given in the actual implementation (at least in my setup of Python), so also state it here.