### PR TITLE
upgrade dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.12
   - setuptools
   - pip
   - xtandem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ version = "0.0.1"
 requires-python = ">=3.11"
 
 dependencies = [
-    "pandas >= 2, < 2.1.0",
-    "pyteomics >= 4.6, < 5",
-    "lxml >= 4.9.3, < 5",
-    "sqlalchemy >= 2, < 3",
+    "pandas ~= 2.0",
+    "pyteomics ~= 4.6",
+    "lxml ~= 4.9.3",
+    "sqlalchemy ~= 2.0",
 ]
 
 


### PR DESCRIPTION
- newer pyteomics does not need restricted Pandas anymore (-> update of versions)
- update of Python  to 3.12