### PR TITLE
update for comet 2024.1.0

### DIFF
--- a/src/sdrf_convert/comet_converter.py
+++ b/src/sdrf_convert/comet_converter.py
@@ -335,16 +335,19 @@ class CometConverter(AbstractConverter):
             "peptide_mass_tolerance",
             str(peptide_mass_tolerance)
         )
+
+        # since comet 2024.1.0 we need lower and upper tolerance
         sample_config = self.set_param(
             sample_config,
             "peptide_mass_tolerance_lower",
-            str(peptide_mass_tolerance)
+            str(-peptide_mass_tolerance)
         )
         sample_config = self.set_param(
             sample_config,
             "peptide_mass_tolerance_upper",
             str(peptide_mass_tolerance)
         )
+
         sample_config = self.set_param(
             sample_config,
             "peptide_mass_units",

--- a/src/sdrf_convert/comet_converter.py
+++ b/src/sdrf_convert/comet_converter.py
@@ -337,6 +337,16 @@ class CometConverter(AbstractConverter):
         )
         sample_config = self.set_param(
             sample_config,
+            "peptide_mass_tolerance_lower",
+            str(peptide_mass_tolerance)
+        )
+        sample_config = self.set_param(
+            sample_config,
+            "peptide_mass_tolerance_upper",
+            str(peptide_mass_tolerance)
+        )
+        sample_config = self.set_param(
+            sample_config,
             "peptide_mass_units",
             str(peptide_mass_tolerance_unit)
         )


### PR DESCRIPTION
since comet 2024.1.0, the `peptide_mass_tolerance_lower` and `peptide_mass_tolerance_upper` is needed.